### PR TITLE
Updated the TAG definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -2187,5 +2187,6 @@ fun Snackbar.action(text: String, @ColorRes color: Int? = null, listener: (View)
 /**
  * Extension method to get the TAG name for all object
  */
-fun <T : Any> T.TAG() = this::class.simpleName
+val <T : Any> T.TAG
+    get() = this::class.simpleName
 ```


### PR DESCRIPTION
The TAG definition required a function call, which is not really clean code since it should act as a constant.  Switched it over to a constant with a getter() - much nicer in the logs.  Means you can drop the ().  i.e. `Log.i(TAG(), "some msg")` becomes `Log.i(TAG, "some msg")`.

 
